### PR TITLE
Change parameter order in figure4_5_no_sklearn.py

### DIFF
--- a/ch02/chapter.py
+++ b/ch02/chapter.py
@@ -84,7 +84,7 @@ print(best_fi, best_t, best_reverse, best_acc)
 
 def is_virginica_test(fi, t, reverse, example):
     'Apply threshold model to a new example'
-    test = example[fi] > t
+    test = example[:, fi] > t
     if reverse:
         test = not test
     return test

--- a/ch02/chapter.py
+++ b/ch02/chapter.py
@@ -84,7 +84,7 @@ print(best_fi, best_t, best_reverse, best_acc)
 
 def is_virginica_test(fi, t, reverse, example):
     'Apply threshold model to a new example'
-    test = example[:, fi] > t
+    test = example[fi] > t
     if reverse:
         test = not test
     return test

--- a/ch02/figure4_5_no_sklearn.py
+++ b/ch02/figure4_5_no_sklearn.py
@@ -45,7 +45,7 @@ def plot_decision(features, labels):
 
     model = fit_model(1, features[:, (0, 2)], np.array(labels))
     C = predict(
-        np.vstack([X.ravel(), Y.ravel()]).T, model).reshape(X.shape)
+        model, np.vstack([X.ravel(), Y.ravel()]).T).reshape(X.shape)
     if COLOUR_FIGURE:
         cmap = ListedColormap([(1., .6, .6), (.6, 1., .6), (.6, .6, 1.)])
     else:


### PR DESCRIPTION
In `figure4_5_no_sklearn.py`, we need to change the order of parameter for fixing following error.
```
Boks-MacBook-Pro:ch02 inmobi$ python figure4_5_no_sklearn.py
Traceback (most recent call last):
  File "figure4_5_no_sklearn.py", line 73, in <module>
    fig,ax = plot_decision(features, labels)
  File "figure4_5_no_sklearn.py", line 48, in plot_decision
    np.vstack([X.ravel(), Y.ravel()]).T, model).reshape(X.shape)


  File "/Users/inmobi/project/BuildingMachineLearningSystemsWithPython/ch02/knn.py", line 31, in predict
    k, train_feats, labels = model
ValueError: too many values to unpack
```