### PR TITLE
Mismatch in funcation declartion and it's call

### DIFF
--- a/ch10/features.py
+++ b/ch10/features.py
@@ -37,7 +37,7 @@ def texture(im):
     return mh.features.haralick(im).ravel()
 
 
-def chist(im):
+def color_histogram(im):
     '''Compute color histogram of input image
 
     Parameters


### PR DESCRIPTION
in features.py chist(im) function is defined
 but in simpleclassification.py 
from features import texture, color_histogram
is used, so method not found/ not defined error will be raised.

Solution: Changing either of these. i have change the function definition.