### PR TITLE
ch01: make a slice index an integer

### DIFF
--- a/ch01/analyze_webstats.py
+++ b/ch01/analyze_webstats.py
@@ -81,7 +81,7 @@ plot_models(
     x, y, [f1, f2, f3, f10, f100], os.path.join(CHART_DIR, "1400_01_04.png"))
 
 # fit and plot a model using the knowledge about inflection point
-inflection = 3.5 * 7 * 24
+inflection = int(3.5 * 7 * 24)
 xa = x[:inflection]
 ya = y[:inflection]
 xb = x[inflection:]


### PR DESCRIPTION
Fix a TypeError below.
```
[[1.000e+00 2.272e+03]
 [2.000e+00       nan]
 [3.000e+00 1.386e+03]
 [4.000e+00 1.365e+03]
 [5.000e+00 1.488e+03]
 [6.000e+00 1.337e+03]
 [7.000e+00 1.883e+03]
 [8.000e+00 2.283e+03]
 [9.000e+00 1.335e+03]
 [1.000e+01 1.025e+03]]
(743, 2)
('Number of invalid entries:', 8)
Model parameters of fp1: [  2.59619213 989.02487106]
('Error of the model of fp1:', array([3.17389767e+08]))
Model parameters of fp2: [ 1.05322215e-02 -5.26545650e+00  1.97476082e+03]
('Error of the model of fp2:', array([1.79983508e+08]))
/usr/local/lib/python2.7/site-packages/numpy/lib/polynomial.py:583: RuntimeWarning: overflow encountered in multiply
  scale = NX.sqrt((lhs*lhs).sum(axis=0))
/usr/local/lib/python2.7/site-packages/numpy/core/_methods.py:32: RuntimeWarning: overflow encountered in reduce
  return umr_sum(a, axis, dtype, out, keepdims)
analyze_webstats.py:76: RankWarning: Polyfit may be poorly conditioned
  f100 = sp.poly1d(sp.polyfit(x, y, 100))
Traceback (most recent call last):
  File "analyze_webstats.py", line 85, in <module>
    xa = x[:inflection]
TypeError: slice indices must be integers or None or have an __index__ method
```